### PR TITLE
Remove template params that prevent compilation where copy is necessary

### DIFF
--- a/result.h
+++ b/result.h
@@ -668,7 +668,6 @@ struct Constructor<void, E> {
     static void move(Storage<void, E>&& src, Storage<void, E>& dst, ok_tag) {
     }
 
-    template<typename U>
     static void copy(const Storage<void, E>& src, Storage<void, E>& dst, ok_tag) {
     }
 
@@ -677,7 +676,6 @@ struct Constructor<void, E> {
         src.destroy(err_tag());
     }
 
-    template<typename U>
     static void copy(const Storage<void, E>& src, Storage<void, E>& dst, err_tag) {
         dst.rawConstruct(src.template get<E>());
     }


### PR DESCRIPTION
The extra template params on the copy methods aren't used and are unnecessary. Playing around with the library earlier, it actually prevented compilation of some code, where removing it allowed the code to compile. Can't remember the exact code I used, but I don't see why these need to exist here.