### PR TITLE
use `__extension__` for compound statements

### DIFF
--- a/result.h
+++ b/result.h
@@ -895,7 +895,7 @@ bool operator==(const Result<T, E>& lhs, types::Err<E> err) {
 }
 
 #define TRY(...)                                                   \
-    ({                                                             \
+    __extension__ ({                                               \
         auto res = __VA_ARGS__;                                    \
         if (!res.isOk()) {                                         \
             typedef details::ResultErrType<decltype(res)>::type E; \


### PR DESCRIPTION
See https://stackoverflow.com/questions/1238016/are-compound-statements-blocks-surrounded-by-parens-expressions-in-ansi-c for reasoning.